### PR TITLE
Fix frontend response parsing and ignore local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,31 @@
 .venv
 .vscode
+.env
 __pycache__
 node_modules
 myenv/
+dist
+*.log
+*.out
+*.err
+*.pid
+*.tmp
+*.temp
+~$*.docx
+*.swp
+
+# Python caches and local envs
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.pyc
+*.pyo
+*.pyd
+
+# Backend local runtime files
+fake-news-detector-backend/Agents/*.log
+fake-news-detector-backend/Agents/*_data.json
+fake-news-detector-backend/Agents/.env
+
+# Frontend local build output
+fake-news-detector-frontend/dist/

--- a/fake-news-detector-frontend/src/components/custom/fakeNewsChecker.jsx
+++ b/fake-news-detector-frontend/src/components/custom/fakeNewsChecker.jsx
@@ -1,7 +1,6 @@
 import { Input } from "@/components/ui/input.jsx"
 import { Button } from "@/components/ui/button.jsx"
 import { Switch } from "@/components/ui/switch"
-import { Label } from "@/components/ui/label"
 import { Sun, Moon } from "lucide-react"
 import { useState } from "react"
 import Typewriter from "typewriter-effect"
@@ -11,35 +10,31 @@ import { set } from "date-fns"
 
 function parseBackendResponse(message) {
     const normalized = (message || "").replace(/\r\n/g, "\n").trim()
-    const labels = ["Verdict", "Reason", "Summary", "Sources"]
-    const sections = {}
+    const sections = {
+        Verdict: "",
+        Reason: "",
+        Summary: "",
+        Sources: "",
+    }
+    const sectionPattern = /(?:^|\n)\s*\**(Verdict|Reason(?:ing)?|Summary|Sources)\**\s*[:\-]\s*([\s\S]*?)(?=(?:\n\s*\**(?:Verdict|Reason(?:ing)?|Summary|Sources)\**\s*[:\-])|$)/gi
 
-    for (let i = 0; i < labels.length; i++) {
-        const label = labels[i]
-        const start = normalized.indexOf(`${label}:`)
+    for (const match of normalized.matchAll(sectionPattern)) {
+        const rawLabel = match[1]
+        const value = match[2]?.trim() || ""
+        const normalizedLabel = rawLabel.toLowerCase().startsWith("reason")
+            ? "Reason"
+            : rawLabel.charAt(0).toUpperCase() + rawLabel.slice(1).toLowerCase()
 
-        if (start === -1) {
-            sections[label] = ""
-            continue
-        }
-
-        const valueStart = start + label.length + 1
-        let end = normalized.length
-
-        for (let j = i + 1; j < labels.length; j++) {
-            const nextStart = normalized.indexOf(`\n${labels[j]}:`, valueStart)
-            if (nextStart !== -1) {
-                end = nextStart
-                break
-            }
-        }
-
-        sections[label] = normalized.slice(valueStart, end).trim()
+        sections[normalizedLabel] = value
     }
 
+    const fallbackReason = normalized && Object.values(sections).every((value) => !value)
+        ? normalized
+        : "No reasoning available."
+
     return {
-        verdict: sections.Verdict || "Unknown",
-        reasoning: sections.Reason || "No reasoning available.",
+        verdict: sections.Verdict || (normalized.toLowerCase().startsWith("error") ? "Error" : "Unknown"),
+        reasoning: sections.Reason || fallbackReason,
         summary: !sections.Summary || sections.Summary.toLowerCase() === "null"
             ? "No summary available."
             : sections.Summary,
@@ -199,6 +194,7 @@ function FakeNewsChecker() {
                         </h2>
 
                         <Typewriter
+                            key={sources}
                             className="text-gray-700 dark:text-gray-300"
                             options={{
                                 strings: [sources || 'Sources will appear here after checking.'],
@@ -221,6 +217,7 @@ function FakeNewsChecker() {
                             </h2>
 
                             <Typewriter
+                                key={reasoning}
                                 className="text-gray-700 dark:text-gray-300"
                                 options={{
                                     strings: [reasoning || 'Reasoning will appear here after checking.'],
@@ -239,6 +236,7 @@ function FakeNewsChecker() {
                                 Summary
                             </h2>
                             <Typewriter
+                                key={summary}
                                 className="text-gray-700 dark:text-gray-300"
                                 options={{
                                     strings: [summary || "Summary will appear here after checking."],


### PR DESCRIPTION
 Title
  Fix frontend response parsing and ignore local artifacts

  Description
  This PR fixes the frontend rendering issue where Verdict, Sources, and Summary were not displaying reliably after
  recent backend response-flow changes.

  What changed

  - Hardened frontend response parsing to handle more backend text variants instead of assuming one strict format
  - Added fallback handling for partially structured or plain-text responses
  - Ensured the Typewriter output remounts correctly when a new response arrives
  - Updated .gitignore to exclude local-only artifacts:
      - backend agent logs
      - agent runtime data files
      - nested backend .env
      - frontend dist/
      - caches, temp files, and Office lock files

  Why
  The frontend was tightly coupled to a specific plain-text backend response shape. After the newer backend chat-based
  flow, small formatting variations could break parsing and prevent sections from rendering.

  Files changed

  - .gitignore
  - fake-news-detector-frontend/src/components/custom/fakeNewsChecker.jsx

  Verification

  - Verified local frontend build passes
  - Confirmed the UI renders Verdict, Sources, and Summary correctly during local testing